### PR TITLE
refactor: 將散落的硬編碼外部 URL 統一移至 config.py

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -46,3 +46,13 @@ RUTEN_API_BASE_URL = "https://rtapi.ruten.com.tw/api"
 
 # 露天拍賣商品圖片的 Base URL
 RUTEN_IMAGE_BASE_URL = "https://gcs.rimg.com.tw"
+
+# 露天拍賣網站 Base URL（商品頁面、Referer 用）
+RUTEN_BASE_URL = "https://www.ruten.com.tw"
+
+# ============================================================
+# Konami 官方資料庫（Referer 用）
+# ============================================================
+
+# Konami 官方網站 Base URL（Referer 用）
+KONAMI_REFERER_URL = "https://www.db.yugioh-card.com/"

--- a/app/routers/health.py
+++ b/app/routers/health.py
@@ -12,9 +12,11 @@ from fastapi import APIRouter, Request
 from pydantic import BaseModel
 
 from app.config import (
+    CARD_IMAGE_BASE_URL,
     CARDS_CDB_URL,
     CID_TABLE_URL,
     KONAMI_DB_BASE_URL,
+    RUTEN_API_BASE_URL,
 )
 
 logger = logging.getLogger(__name__)
@@ -55,11 +57,11 @@ _DEPENDENCIES = [
     {"name": "salix5 CID 對照表", "url": CID_TABLE_URL},
     # CARD_IMAGE_BASE_URL 是目錄路徑（trailing slash），對目錄發 HEAD 會回 404
     # 改用已知存在的卡圖檔案作為 probe URL
-    {"name": "salix5 卡圖", "url": "https://raw.githubusercontent.com/salix5/query-data/refs/heads/master/pics/89631139.jpg"},
+    {"name": "salix5 卡圖", "url": f"{CARD_IMAGE_BASE_URL}89631139.jpg"},
     {"name": "Konami 官方 DB", "url": KONAMI_DB_BASE_URL},
     # RUTEN_API_BASE_URL 是 base URL，對它發 HEAD 會回 404/405
     # 改用實際可回應的 search endpoint 作為 probe URL
-    {"name": "露天拍賣 API", "url": "https://rtapi.ruten.com.tw/api/search/v3/index.php/core/prod?q=test&limit=1"},
+    {"name": "露天拍賣 API", "url": f"{RUTEN_API_BASE_URL}/search/v3/index.php/core/prod?q=test&limit=1"},
 ]
 
 

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -12,6 +12,7 @@ import os
 
 from fastapi import APIRouter, HTTPException
 
+from app.config import RUTEN_BASE_URL
 from app.services import storage
 from app.services.calculator_service import PurchaseOptimizer
 from app.services.cleaner_service import DataCleaner
@@ -144,7 +145,7 @@ async def get_results(project_name: str):
                 "name": item.get("product_name", ""),
                 # 用 product_id 組合露天商品頁面網址
                 "url": (
-                    f"https://www.ruten.com.tw/item/show?{product_id}"
+                    f"{RUTEN_BASE_URL}/item/show?{product_id}"
                     if product_id
                     else ""
                 ),

--- a/app/services/konami_scraper.py
+++ b/app/services/konami_scraper.py
@@ -16,7 +16,7 @@ from fake_useragent import UserAgent
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from app.config import KONAMI_DB_BASE_URL
+from app.config import KONAMI_DB_BASE_URL, KONAMI_REFERER_URL
 
 # 設定日誌格式，方便追蹤程式執行狀況與錯誤
 logger = logging.getLogger(__name__)
@@ -58,7 +58,7 @@ class KonamiScraper:
                 "User-Agent": self.ua.random,
                 "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
                 "Accept-Language": "ja,en-US;q=0.7,en;q=0.3",
-                "Referer": "https://www.db.yugioh-card.com/",
+                "Referer": KONAMI_REFERER_URL,
                 "Connection": "keep-alive",
                 "Upgrade-Insecure-Requests": "1",
             }

--- a/app/services/ruten_scraper.py
+++ b/app/services/ruten_scraper.py
@@ -21,7 +21,7 @@ from fake_useragent import UserAgent
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from app.config import RUTEN_API_BASE_URL, RUTEN_IMAGE_BASE_URL
+from app.config import RUTEN_API_BASE_URL, RUTEN_BASE_URL, RUTEN_IMAGE_BASE_URL
 
 # 設定日誌
 logger = logging.getLogger(__name__)
@@ -83,7 +83,7 @@ class RutenScraper:
                 "User-Agent": self.ua.random,
                 "Accept": "application/json",
                 "Accept-Language": "zh-TW,zh;q=0.9,en-US;q=0.8,en;q=0.7",
-                "Referer": "https://www.ruten.com.tw/",
+                "Referer": f"{RUTEN_BASE_URL}/",
                 "Connection": "keep-alive",
             }
         except Exception as e:
@@ -92,7 +92,7 @@ class RutenScraper:
                 "User-Agent": DEFAULT_USER_AGENT,
                 "Accept": "application/json",
                 "Accept-Language": "zh-TW,zh;q=0.9,en-US;q=0.8,en;q=0.7",
-                "Referer": "https://www.ruten.com.tw/",
+                "Referer": f"{RUTEN_BASE_URL}/",
                 "Connection": "keep-alive",
             }
 


### PR DESCRIPTION
## Summary
- 在 `config.py` 新增 `RUTEN_BASE_URL`、`KONAMI_REFERER_URL` 兩個常數
- `health.py` 的 salix5 卡圖與露天 API probe URL 改從 config 常數組成
- `ruten_scraper.py` Referer、`tasks.py` 商品頁面 URL 改用 `RUTEN_BASE_URL`
- `konami_scraper.py` Referer 改用 `KONAMI_REFERER_URL`

## Test Plan
- [ ] 28 tests passing (`pytest`)
- [ ] `/api/health/dependencies` 回傳各外部服務正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)