### PR TITLE
feat: 複數選項商品展開為獨立資料列（#4 + #5）

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -50,6 +50,9 @@ RUTEN_IMAGE_BASE_URL = "https://gcs.rimg.com.tw"
 # 露天拍賣網站 Base URL（商品頁面、Referer 用）
 RUTEN_BASE_URL = "https://www.ruten.com.tw"
 
+# 露天拍賣 items API Base URL（商品詳細選項查詢用）
+RUTEN_ITEMS_API_BASE_URL = "https://rapi.ruten.com.tw/api"
+
 # ============================================================
 # Konami 官方資料庫（Referer 用）
 # ============================================================

--- a/app/services/cleaner_service.py
+++ b/app/services/cleaner_service.py
@@ -166,7 +166,7 @@ class DataCleaner:
                         pass  # 價格不是數字就保留
 
                     # 過濾 3: 有價差的商品（多種規格，爬蟲無法確定是哪種）
-                    if row.get("alt_price") == "1":
+                    if row.get("alt_price") == "True":
                         continue
 
                     product_name = row.get("product_name", "")

--- a/app/services/ruten_scraper.py
+++ b/app/services/ruten_scraper.py
@@ -21,7 +21,12 @@ from fake_useragent import UserAgent
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from app.config import RUTEN_API_BASE_URL, RUTEN_BASE_URL, RUTEN_IMAGE_BASE_URL, RUTEN_ITEMS_API_BASE_URL
+from app.config import (
+    RUTEN_API_BASE_URL,
+    RUTEN_BASE_URL,
+    RUTEN_IMAGE_BASE_URL,
+    RUTEN_ITEMS_API_BASE_URL,
+)
 
 # 設定日誌
 logger = logging.getLogger(__name__)

--- a/app/services/ruten_scraper.py
+++ b/app/services/ruten_scraper.py
@@ -21,7 +21,7 @@ from fake_useragent import UserAgent
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from app.config import RUTEN_API_BASE_URL, RUTEN_BASE_URL, RUTEN_IMAGE_BASE_URL
+from app.config import RUTEN_API_BASE_URL, RUTEN_BASE_URL, RUTEN_IMAGE_BASE_URL, RUTEN_ITEMS_API_BASE_URL
 
 # 設定日誌
 logger = logging.getLogger(__name__)
@@ -173,13 +173,11 @@ class RutenScraper:
                 else 0
             )
 
-            alt_price = 0
-            if (
-                price_range
+            alt_price = (
+                bool(price_range)
                 and len(price_range) > 1
                 and price_range[0] != price_range[-1]
-            ):
-                alt_price = 1
+            )
 
             shipping_cost = product.get("ShippingCost")
             shipping_cost = int(shipping_cost) if shipping_cost is not None else 0
@@ -187,19 +185,70 @@ class RutenScraper:
             image_url = product.get("Image", "")
 
             return {
-                "商品ID": product.get("ProdId", ""),
-                "商品名稱": product.get("ProdName", ""),
-                "賣家ID": product.get("SellerId", ""),
-                "價格": price,
-                "是否有價差": alt_price,
-                "剩餘數量": remaining_stock,
-                "最低運費": shipping_cost,
-                "上架時間": product.get("PostTime", ""),
-                "圖片連結": image_url,
+                "product_id": product.get("ProdId", ""),
+                "product_name": product.get("ProdName", ""),
+                "seller_id": product.get("SellerId", ""),
+                "price": price,
+                "alt_price": alt_price,
+                "stock_qty": remaining_stock,
+                "shipping_cost": shipping_cost,
+                "post_time": product.get("PostTime", ""),
+                "image_url": image_url,
             }
         except Exception as e:
             logger.error(f"處理商品資料時發生錯誤：{e}")
             return None
+
+    async def _fetch_item_detail_async(self, product_id: str) -> dict | None:
+        """[非同步] 取得單一商品的 items/v2 level=detail 資料（含各選項的獨立庫存與價格）"""
+        url = f"{RUTEN_ITEMS_API_BASE_URL}/items/v2/list"
+        params = {"gno": product_id, "level": "detail"}
+
+        async with aiohttp.ClientSession() as session:
+            try:
+                async with session.get(
+                    url,
+                    params=params,
+                    headers=self._get_headers(),
+                    timeout=DEFAULT_TIMEOUT,
+                ) as response:
+                    result = await response.json()
+                    data = result.get("data", [])
+                    return data[0] if data else None
+            except Exception as e:
+                logger.warning(f"取得商品 {product_id} 的選項詳情失敗: {e}")
+                return None
+
+    def _expand_variants(self, parent: Dict, item_detail: dict) -> List[Dict]:
+        """
+        將 items/v2 level=detail 的 spec_info.specs 展開為多筆獨立商品資料列。
+        每筆子商品繼承父商品的 seller_id、image_url、post_time、search_card_name，
+        以自己的 spec_price、spec_num 覆蓋，alt_price 設為 False。
+        回傳空列表表示無法展開（應保留原始資料列）。
+        """
+        specs = item_detail.get("spec_info", {}).get("specs", {})
+        if not specs:
+            return []
+
+        variants = []
+        for spec_id, spec in specs.items():
+            if spec.get("spec_status") != "Y":
+                continue
+            variant = {
+                "product_id": f"{parent['product_id']}_{spec_id}",
+                "product_name": f"{parent['product_name']} [{spec['spec_name']}]",
+                "seller_id": parent["seller_id"],
+                "price": int(spec.get("spec_price", 0)),
+                "alt_price": False,
+                "stock_qty": int(spec.get("spec_num", 0)),
+                "shipping_cost": parent["shipping_cost"],
+                "post_time": parent["post_time"],
+                "image_url": parent["image_url"],
+            }
+            if "search_card_name" in parent:
+                variant["search_card_name"] = parent["search_card_name"]
+            variants.append(variant)
+        return variants
 
     async def _process_products_async(
         self, keyword: str, max_pages: int = 999
@@ -234,6 +283,7 @@ class RutenScraper:
                     break
 
                 # 多工處理資料轉換
+                page_products = []
                 with ThreadPoolExecutor(max_workers=MAX_CONCURRENT_REQUESTS) as executor:
                     futures = [
                         executor.submit(self._extract_product_data, product)
@@ -242,7 +292,22 @@ class RutenScraper:
                     for future in as_completed(futures):
                         product_data = future.result()
                         if product_data:
-                            all_products.append(product_data)
+                            page_products.append(product_data)
+
+                # 對有複數選項的商品展開選項
+                for product in page_products:
+                    if not product.get("alt_price"):
+                        all_products.append(product)
+                        continue
+                    item_detail = await self._fetch_item_detail_async(product["product_id"])
+                    variants = self._expand_variants(product, item_detail) if item_detail else []
+                    if variants:
+                        all_products.extend(variants)
+                    else:
+                        logger.warning(
+                            f"商品 {product.get('product_id')} 選項展開失敗，保留原始資料列"
+                        )
+                        all_products.append(product)
 
                 # 如果這頁不滿，代表沒有下一頁了
                 if len(search_result["Rows"]) < ITEMS_PER_PAGE:
@@ -269,20 +334,6 @@ class RutenScraper:
 
         try:
             df = pd.DataFrame(data)
-            # 將中文欄位名稱轉換為英文
-            df = df.rename(
-                columns={
-                    "商品ID": "product_id",
-                    "商品名稱": "product_name",
-                    "賣家ID": "seller_id",
-                    "價格": "price",
-                    "是否有價差": "alt_price",
-                    "剩餘數量": "stock_qty",
-                    "最低運費": "shipping_cost",
-                    "上架時間": "post_time",
-                    "圖片連結": "image_url",
-                }
-            )
 
             # 調整欄位順序，把 'search_card_name' 移到最前面
             cols = df.columns.tolist()

--- a/openspec/changes/ruten-multi-option-expansion/.openspec.yaml
+++ b/openspec/changes/ruten-multi-option-expansion/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-06

--- a/openspec/changes/ruten-multi-option-expansion/design.md
+++ b/openspec/changes/ruten-multi-option-expansion/design.md
@@ -1,0 +1,63 @@
+## Context
+
+目前 `RutenScraper._process_products_async()` 是單階段流程：搜尋 API → `_get_product_details_async()` → `_extract_product_data()`。複數選項商品（`PriceRange` 有多個不同值）被標記為 `alt_price=1`，在 cleaner 階段整筆排除，完全無法參與比價。
+
+露天 `items/v2/list?gno={id}&level=detail` 可取得商品的 `sub_items[]` 陣列，每個子項目含獨立的名稱、價格、庫存。由於此 API 一次只支援單一商品查詢，僅對已標記 `alt_price=True` 的商品才觸發，避免全量呼叫。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 對 `alt_price=True` 的商品展開子選項為獨立資料列
+- 展開後每筆子商品的 `alt_price=False`，可通過 cleaner 過濾
+- `alt_price` 欄位值從整數 `0/1` 改為布林 `False/True`
+
+**Non-Goals:**
+- 不使用 items/v2 取得運費（單次查詢成本過高，不批量）
+- 不修改 cleaner、calculator、API 端點的核心邏輯
+- 不處理 #6 運費精算、#7 賣家 storeinfo
+
+## Decisions
+
+### 決策 1：第二階段僅對 alt_price 商品觸發
+
+**選擇**：在 `_process_products_async()` 中，完成第一階段資料提取後，過濾出 `alt_price=True` 的商品再逐一呼叫 items/v2。
+
+**替代方案**：全量打 items/v2（level=simple 或 detail）
+**否決理由**：一次只能查一個商品，若對全部 550 筆打 API 成本過高，且多數商品無需此資訊。
+
+### 決策 2：展開後子商品取代原商品（而非並列）
+
+**選擇**：若商品有 sub_items，移除原始資料列，插入展開的子商品列。
+
+**替代方案**：保留原始列 + 追加子商品列
+**否決理由**：若兩者並存，原始列的 `alt_price=True` 仍會被 cleaner 排除，且會造成重複計算。取代更乾淨。
+
+### 決策 3：alt_price 改為布林值
+
+**選擇**：`_extract_product_data()` 回傳 `alt_price: bool`，CSV 儲存為 `True/False`。
+
+**替代方案**：維持 `0/1` 整數
+**否決理由**：整數語意不直觀（在我們的討論中已確認），改布林更清楚。cleaner 的判斷條件 `== "1"` 需同步改為 `== "True"`（CSV 讀回來是字串）。
+
+### 決策 4：items/v2 呼叫採循序非同步，不並行
+
+**選擇**：`for` loop 逐一 `await`，每次呼叫間加短暫 sleep。
+
+**替代方案**：`asyncio.gather()` 並行所有 alt_price 商品
+**否決理由**：alt_price 商品數量通常不多，且並行大量單次查詢可能觸發 rate limiting。循序呼叫更安全。
+
+## Risks / Trade-offs
+
+- **sub_items 結構未知**：items/v2 level=detail 的 `sub_items` 欄位格式需實測確認（鍵名、是否有空值）→ 加防禦性 `.get()` 存取，遇到解析失敗時保留原始資料列（fallback to alt_price=True）
+- **展開後子商品的 product_id 重複**：子商品可能沿用父商品 ID，需確認 cleaner 的去重邏輯是否受影響 → 實作時確認 sub_items 是否有獨立 ID，若無則以 `{parent_id}_{index}` 組合
+- **cleaner `alt_price == "1"` 判斷**：改為布林後 CSV 儲存為字串 `"True"`，需同步修改 cleaner 判斷條件
+
+## Open Questions
+
+~~- items/v2 level=detail 的 `sub_items` 實際 JSON 結構？（鍵名待實測確認）~~
+~~- sub_items 中的子商品是否有獨立的商品 URL / product_id？~~
+
+**已確認（2026-04-06 實測）：**
+- 選項資料在 `data[0].spec_info.specs`（dict），非 `sub_items` 陣列
+- 每個 spec 有 `spec_id`（字串）、`spec_name`、`spec_price`、`spec_num`（庫存）、`spec_status`（`"Y"`=可售）
+- 子選項**無獨立 product_id**，使用 `{parent_id}_{spec_id}` 組合作為唯一識別

--- a/openspec/changes/ruten-multi-option-expansion/proposal.md
+++ b/openspec/changes/ruten-multi-option-expansion/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+露天拍賣中部分商品含有複數選項（如不同稀有度），目前爬蟲只記錄 `alt_price=1` 並在 cleaner 階段整筆排除，導致這些商品完全無法參與比價。透過 items/v2 `level=detail` API 將複數選項展開為獨立資料列，可讓這些商品重新進入計算流程。
+
+## What Changes
+
+- 新增 `_fetch_item_detail_async()` 方法：對單一商品呼叫 `items/v2/list?gno={id}&level=detail`
+- 新增 `_expand_variants()` 方法：將 sub_items 展開為多筆獨立商品資料列，`alt_price` 設為 `False`
+- `_process_products_async()` 中，第一階段完成後針對 `alt_price=True` 的商品執行第二階段展開
+- `alt_price` 欄位語意從 `0/1` 整數改為 `False/True` 布林值（`has_variants` 命名保留為內部處理語意）
+- cleaner_service.py 的 `alt_price == "1"` 過濾邏輯：展開後的子商品 `alt_price=False`，自然通過此過濾，無需額外修改
+- 移除運費相關的 items/v2 查詢計畫（一次只能查一個商品，批量成本過高）
+
+## Capabilities
+
+### New Capabilities
+
+- `multi-option-expansion`: 對 alt_price 商品呼叫 items/v2 level=detail，將各選項展開為獨立資料列加入 CSV
+
+### Modified Capabilities
+
+（無，現有 spec 不涉及爬蟲內部欄位語意）
+
+## Impact
+
+- `app/services/ruten_scraper.py`：新增兩個方法，修改 `_process_products_async()` 主流程
+- `ruten_data.csv` 結構：`alt_price` 欄位值由 `0/1` 改為 `False/True`；原本被排除的複數選項商品現在會展開後出現在 CSV 中
+- `app/services/cleaner_service.py`：`alt_price == "1"` 判斷需同步改為判斷 `True`（小幅修改）
+- 不影響 calculator_service.py、storage.py、API 端點

--- a/openspec/changes/ruten-multi-option-expansion/specs/multi-option-expansion/spec.md
+++ b/openspec/changes/ruten-multi-option-expansion/specs/multi-option-expansion/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: 複數選項商品展開為獨立資料列
+爬蟲 SHALL 對 `alt_price=True` 的商品呼叫 `items/v2/list?gno={id}&level=detail`，將 `sub_items` 陣列中的每個選項展開為獨立資料列，並以展開後的子商品取代原始商品列。展開後每筆子商品的 `alt_price` SHALL 設為 `False`。
+
+#### Scenario: 正常展開複數選項
+- **WHEN** 商品 PriceRange 有多個不同值（alt_price=True）
+- **THEN** 爬蟲呼叫 items/v2 level=detail 取得 sub_items
+- **THEN** 每個 sub_item 展開為獨立資料列（含各自的名稱、價格、庫存）
+- **THEN** 展開後的子商品 alt_price=False，可通過 cleaner 的過濾
+
+#### Scenario: items/v2 呼叫失敗或 sub_items 為空
+- **WHEN** items/v2 API 呼叫失敗，或回傳的 sub_items 為空陣列
+- **THEN** 保留原始商品列（alt_price=True），不丟棄任何資料
+- **THEN** 記錄警告日誌
+
+#### Scenario: 商品只有單一選項（alt_price=False）
+- **WHEN** 商品 PriceRange 只有一個值，或最低價等於最高價
+- **THEN** 不呼叫 items/v2，直接使用原始資料列
+
+### Requirement: alt_price 欄位使用布林值
+爬蟲輸出的 CSV SHALL 以 `True`/`False` 字串表示 `alt_price` 欄位，取代原本的 `1`/`0` 整數。cleaner_service.py 的過濾條件 SHALL 同步更新為判斷字串 `"True"`。
+
+#### Scenario: 有價差商品的欄位值
+- **WHEN** 商品展開前 alt_price 為 True（或展開失敗保留原始列）
+- **THEN** CSV 中 alt_price 欄位值為字串 `"True"`
+
+#### Scenario: 無價差或已展開商品的欄位值
+- **WHEN** 商品為單一選項，或已成功展開為子商品列
+- **THEN** CSV 中 alt_price 欄位值為字串 `"False"`
+
+#### Scenario: cleaner 正確過濾未展開的複數選項商品
+- **WHEN** cleaner 讀取 CSV，遇到 alt_price="True" 的資料列
+- **THEN** 該列被排除，不進入 calculator

--- a/openspec/changes/ruten-multi-option-expansion/tasks.md
+++ b/openspec/changes/ruten-multi-option-expansion/tasks.md
@@ -1,0 +1,21 @@
+## 1. 實測 items/v2 level=detail API
+
+- [x] 1.1 手動對一個已知有複數選項的商品呼叫 `items/v2/list?gno={id}&level=detail`，確認 sub_items 的實際 JSON 結構（鍵名、子商品是否有獨立 ID）
+- [x] 1.2 確認子商品的 product_id 格式，決定是否需要用 `{parent_id}_{index}` 組合
+
+## 2. ruten_scraper.py：核心修改
+
+- [x] 2.1 `_extract_product_data()` 的 `alt_price` 回傳值從 `0/1` 整數改為 `False/True` 布林值
+- [x] 2.2 新增 `_fetch_item_detail_async(product_id: str) -> dict | None`：呼叫 items/v2 level=detail，失敗時回傳 None
+- [x] 2.3 新增 `_expand_variants(parent_product: dict, sub_items: list) -> list[dict]`：將 sub_items 展開為多筆商品 dict，`alt_price=False`，其餘欄位（seller_id、image_url 等）繼承父商品
+- [x] 2.4 修改 `_process_products_async()`：第一階段結束後，對 `alt_price=True` 的商品逐一 await `_fetch_item_detail_async()`，展開後取代原始列；API 失敗時保留原始列並記錄警告
+
+## 3. cleaner_service.py：同步修改
+
+- [x] 3.1 將 `alt_price == "1"` 的判斷改為 `alt_price == "True"`
+
+## 4. 驗證
+
+- [x] 4.1 用含複數選項商品的購物車跑一次完整爬蟲，確認展開後子商品出現在 ruten_data.csv 且 alt_price 為 "False"
+- [x] 4.2 確認單一選項商品不受影響（不呼叫 items/v2）
+- [x] 4.3 跑完整 run 流程（scrape → clean → calculate），確認展開後的子商品能進入計算結果


### PR DESCRIPTION
## Summary

- 對 `alt_price=True` 的商品呼叫露天 `items/v2/list?gno={id}&level=detail`，將各選項（`spec_info.specs`）展開為獨立資料列
- 展開後子商品 `alt_price=False`，可正常進入 cleaner → calculator 流程
- `alt_price` 欄位從整數 `0/1` 改為布林 `False/True`
- 展開失敗時 fallback 保留原始列

Closes #4, Closes #5

## Test plan

- [x] 實測 items/v2 level=detail API 結構（`spec_info.specs` dict，`spec_id`/`spec_name`/`spec_price`/`spec_num`）
- [x] `_extract_product_data` 布林值輸出正確（單一選項 False、複數選項 True）
- [x] `_expand_variants` 展開 10 筆子選項，product_id = `{parent}_{spec_id}`，alt_price=False
- [x] cleaner `alt_price == "True"` 過濾邏輯正確

🤖 Generated with [Claude Code](https://claude.com/claude-code)